### PR TITLE
Align calendar grid with first weekday offset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,6 +72,7 @@ const exploreBenefits = [
 const calendarYear = 2025;
 const calendarMonth = 1;
 const daysInMonth = new Date(calendarYear, calendarMonth, 0).getDate();
+const firstWeekday = new Date(calendarYear, calendarMonth - 1, 1).getDay();
 
 const calendarDays = Array.from({ length: daysInMonth }, (_, index) => {
   const day = index + 1;
@@ -271,7 +272,7 @@ export default function Home() {
                 </button>
               }
             />
-            <CalendarGrid days={calendarDays} />
+            <CalendarGrid days={calendarDays} firstWeekday={firstWeekday} />
             <div className="mt-4 flex flex-wrap gap-3 text-xs text-slate-500">
               <span className="flex items-center gap-2">
                 <span className="h-2 w-2 rounded-full bg-emerald-400" /> 신청 시작일

--- a/components/CalendarGrid.tsx
+++ b/components/CalendarGrid.tsx
@@ -6,11 +6,14 @@ type CalendarDay = {
 
 type CalendarGridProps = {
   days: CalendarDay[];
+  firstWeekday: number;
 };
 
 const dayLabels = ["일", "월", "화", "수", "목", "금", "토"];
 
-export default function CalendarGrid({ days }: CalendarGridProps) {
+export default function CalendarGrid({ days, firstWeekday }: CalendarGridProps) {
+  const offsetDays = Array.from({ length: firstWeekday });
+
   return (
     <div>
       <div className="mt-6 grid grid-cols-7 gap-2 text-center text-xs font-semibold text-slate-400">
@@ -19,6 +22,9 @@ export default function CalendarGrid({ days }: CalendarGridProps) {
         ))}
       </div>
       <div className="mt-3 grid grid-cols-7 gap-2">
+        {offsetDays.map((_, index) => (
+          <div key={`empty-${index}`} className="h-10" aria-hidden="true" />
+        ))}
         {days.map((item) => (
           <div
             key={item.day}


### PR DESCRIPTION
### Motivation
- The calendar previously rendered day `1` in the first column (Sunday) regardless of the actual first weekday, causing dates to appear under the wrong weekday label.
- The goal is to compute the month start weekday and add leading empty cells so day numbers align under their weekday headings.

### Description
- Added a `firstWeekday` number prop to `CalendarGrid` and compute it in `app/page.tsx` using `new Date(calendarYear, calendarMonth - 1, 1).getDay()`.
- Passed `firstWeekday` into `CalendarGrid` where an `offsetDays` array is created via `Array.from({ length: firstWeekday })`.
- Rendered leading empty grid cells (`<div key={`empty-${index}`} ... />`) before mapping `days` so the grid columns align with `dayLabels`.
- Changes are in `app/page.tsx` and `components/CalendarGrid.tsx`.

### Testing
- Launched the dev server with `npm run dev` and the Next.js app compiled and served successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:3000` and produced a screenshot (`artifacts/calendar-grid-offset.png`) to visually verify the calendar alignment, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966965cbdc88330a7d45da66161c229)